### PR TITLE
Adds a c# acompute shader compiler and example.

### DIFF
--- a/Examples/ExposureShader.cs
+++ b/Examples/ExposureShader.cs
@@ -1,0 +1,68 @@
+using Godot;
+using System.Runtime.InteropServices;
+
+[GlobalClass]
+[Tool]
+public partial class ExposureShader : CompositorEffect
+{
+
+  [Export]
+  private Vector4 m_exposure = new(2, 1, 1, 1);
+
+  private Shader m_exposureShader;
+
+  /// <summary>
+  /// Example compositor effect using the C# shader wrapper.
+  /// </summary>
+  public ExposureShader() : base()
+  {
+    RenderingServer.CallOnRenderThread(Callable.From(() =>
+    {
+
+      // It is possible to just include a resource path to a glsl compute shader
+      // this.m_exposureShader = new("res://exposure_example.glsl");
+      // this.m_exposureShader = new("res://exposure_example.glsl", false);
+
+      // Create a shader wrapper for a custom shader
+      this.m_exposureShader = new("exposure_example", true);
+    }));
+  }
+
+  public override void _RenderCallback(int effectCallbackType, RenderData renderData)
+  {
+    if (!this.Enabled) return;
+    if (effectCallbackType != (int)EffectCallbackTypeEnum.PostTransparent) return;
+
+    RenderSceneBuffersRD renderSceneBuffers = (RenderSceneBuffersRD)renderData.GetRenderSceneBuffers();
+
+    Vector2I size = renderSceneBuffers.GetInternalSize();
+    if (size.X == 0 && size.Y == 0)
+    {
+      GD.PushError("Rendering to 0x0 buffer");
+      return;
+    }
+
+    int xGroups = (size.X - 1) / 8 + 1;
+    int yGroups = (size.Y - 1) / 8 + 1;
+    int zGroups = 1;
+
+    byte[] pushConstant = MemoryMarshal.AsBytes([size.X, size.Y, 0.0f, 0.0f]).ToArray();
+    byte[] uniformArray = MemoryMarshal.AsBytes([this.m_exposure.X, this.m_exposure.Y, this.m_exposure.Z, this.m_exposure.W]).ToArray();
+
+    Rid inputImage = renderSceneBuffers.GetColorLayer(0);
+
+    this.m_exposureShader.SetPushConstant(ref pushConstant);
+    this.m_exposureShader.SetTexture(0, inputImage);
+    this.m_exposureShader.SetUniformBuffer(1, ref uniformArray);
+    this.m_exposureShader.Dispatch(xGroups, yGroups, zGroups);
+  }
+
+  public override void _Notification(int what)
+  {
+    if (what == NotificationPredelete)
+    {
+      this.m_exposureShader.Free();
+    }
+  }
+
+}

--- a/Shader.cs
+++ b/Shader.cs
@@ -1,0 +1,282 @@
+using Godot;
+using Godot.Collections;
+using System.Diagnostics;
+using System.Linq;
+
+public class Shader
+{
+    private readonly string m_shaderName;
+    private readonly bool m_isCustom;
+    private readonly RenderingDevice m_rd;
+    private readonly Rid m_pipeline;
+    private readonly System.Collections.Generic.Dictionary<int, byte[]> m_uniformBufferCache = []; // Contains the contents of the uniform array itself
+    private readonly System.Collections.Generic.Dictionary<int, Rid> m_uniformBufferIdCache = []; // Contains the RIDs for the gpu versions of the uniform array
+    private readonly Array<RDUniform> m_uniformSetCache = [];
+    private readonly Array<Rid> m_kernels = [];
+
+    private Rid m_shader;
+    private Rid m_uniformSetGpuId;
+    private byte[] m_pushConstant;
+    private bool m_refreshUniforms = true;
+
+    /// <summary>
+    /// Creates a new shader wrapper. <para />
+    /// 
+    /// The <c>shaderName</c> can be one of two options. 
+    /// <list type="number">
+    ///     <item>The path to a shader resources i.e. "res://example.glsl"</item>
+    ///     <item>The name of a custom acompute shader i.e. "example"</item>
+    /// </list>
+    /// When <c>isCustom</c> is false, the class expects that the shaderName will be a resource path.
+    /// When <c>isCustom</c> is true, the class expects the shaderName will be a custom shader name.
+    /// 
+    /// </summary>
+    /// <param name="shaderName"></param>
+    /// <param name="isCustom"></param>
+    public Shader(string shaderName, bool isCustom = false)
+    {
+        this.m_isCustom = isCustom;
+        this.m_shaderName = shaderName;
+        this.m_rd = RenderingServer.GetRenderingDevice();
+
+        if (isCustom)
+        {
+            // Wait for our singleton to be created.
+            // This appears to be a race condition between the render thread and something else.
+            if (ShaderCompiler.Instance == null) return;
+
+            this.m_shader = ShaderCompiler.Instance.GetComputeKernelCompilation(shaderName, 0);
+            Debug.Assert(this.m_shader.IsValid, string.Format("Unable to find the requested shader: {0}", shaderName));
+
+            if (!this.m_shader.IsValid)
+            {
+                return;
+            }
+
+            foreach (Rid kernel in ShaderCompiler.Instance.GetComputeKernelCompilations(shaderName))
+            {
+                this.m_kernels.Add(this.m_rd.ComputePipelineCreate(kernel));
+            }
+        }
+        else
+        {
+            RDShaderFile shaderFile = GD.Load<RDShaderFile>(shaderName);
+            Debug.Assert(shaderFile != null, "Unable to load the shader. Make sure you provided the right path.");
+            RDShaderSpirV shaderSpirV = shaderFile.GetSpirV();
+            this.m_shader = this.m_rd.ShaderCreateFromSpirV(shaderSpirV);
+            this.m_pipeline = this.m_rd.ComputePipelineCreate(this.m_shader);
+        }
+    }
+
+    /// <summary>
+    /// Sets the shaders push constant byte array.
+    /// </summary>
+    /// <param name="pushConstant"></param>
+    public void SetPushConstant(ref byte[] pushConstant)
+    {
+        this.m_pushConstant = pushConstant;
+    }
+
+    /// <summary>
+    /// Sets a texture resource bound to the provided binding. The binding value must match the value in the shader file.
+    /// </summary>
+    /// <param name="binding"></param>
+    /// <param name="texture"></param>
+    public void SetTexture(int binding, Rid texture)
+    {
+        RDUniform textureUniform = new()
+        {
+            UniformType = RenderingDevice.UniformType.Image,
+            Binding = binding
+        };
+        textureUniform.AddId(texture);
+        this.CacheUniform(textureUniform);
+    }
+
+    /// <summary>
+    /// Set a uniform buffer resource bound to the provided binding. The binding value must match the value in the shader file.
+    /// </summary>
+    /// <param name="binding"></param>
+    /// <param name="uniformArray"></param>
+    public void SetUniformBuffer(int binding, ref byte[] uniformArray)
+    {
+        // Check if buffer exists
+        if (this.m_uniformBufferCache.TryGetValue(binding, out byte[] cacheValue))
+        {
+            // If buffer is identical, no need to change
+            if (uniformArray.SequenceEqual(cacheValue)) return;
+
+            // If new values but same buffer size, update gpu buffer
+            if (uniformArray.Length == cacheValue.Length)
+            {
+                this.m_rd.BufferUpdate(this.m_uniformBufferIdCache[binding], 0, (uint)uniformArray.Length, uniformArray);
+                this.m_uniformBufferCache[binding] = uniformArray;
+                return;
+            }
+
+            // Otherwise, free the memory because footprint no longer matches
+            this.m_rd.FreeRid(m_uniformBufferIdCache[binding]);
+        }
+
+        Rid uniformBufferId = this.m_rd.UniformBufferCreate((uint)uniformArray.Length, uniformArray);
+
+        RDUniform u = new()
+        {
+            UniformType = RenderingDevice.UniformType.UniformBuffer,
+            Binding = binding
+        };
+        u.AddId(uniformBufferId);
+
+        // Cache array contents and RID
+        this.m_uniformBufferCache[binding] = uniformArray;
+        this.m_uniformBufferIdCache[binding] = uniformBufferId;
+
+        this.CacheUniform(u);
+    }
+
+    /// <summary>
+    /// Sets the compute shader to run. When running a custom shader, it is possible to specify a different kernel index to change which sub shader is run.
+    /// </summary>
+    /// <param name="xGroups"></param>
+    /// <param name="yGroups"></param>
+    /// <param name="zGroups"></param>
+    /// <param name="kernelIndex"></param>
+    public void Dispatch(int xGroups, int yGroups, int zGroups, int kernelIndex = 0)
+    {
+        if (this.m_isCustom)
+        {
+            this.DispatchCustom(xGroups, yGroups, zGroups, kernelIndex);
+        }
+        else
+        {
+            this.DispatchNormal(xGroups, yGroups, zGroups);
+        }
+    }
+
+    /// <summary>
+    /// Runs a normal compute shader.
+    /// </summary>
+    /// <param name="xGroups"></param>
+    /// <param name="yGroups"></param>
+    /// <param name="zGroups"></param>
+    private void DispatchNormal(int xGroups, int yGroups, int zGroups)
+    {
+        // Reallocate GPU memory if uniforms need updating
+        if (this.m_refreshUniforms)
+        {
+            if (this.m_uniformSetGpuId.IsValid) this.m_rd.FreeRid(this.m_uniformSetGpuId);
+            this.m_uniformSetGpuId = this.m_rd.UniformSetCreate(this.m_uniformSetCache, this.m_shader, 0);
+            this.m_refreshUniforms = false;
+        }
+
+        long compute_list = this.m_rd.ComputeListBegin();
+        this.m_rd.ComputeListBindComputePipeline(compute_list, this.m_pipeline);
+        this.m_rd.ComputeListBindUniformSet(compute_list, this.m_uniformSetGpuId, 0);
+        this.m_rd.ComputeListSetPushConstant(compute_list, this.m_pushConstant, (uint)this.m_pushConstant.Length);
+        this.m_rd.ComputeListDispatch(compute_list, (uint)xGroups, (uint)yGroups, (uint)zGroups);
+        this.m_rd.ComputeListEnd();
+    }
+
+    /// <summary>
+    /// Runs a custom compute shader.
+    /// </summary>
+    /// <param name="xGroups"></param>
+    /// <param name="yGroups"></param>
+    /// <param name="zGroups"></param>
+    private void DispatchCustom(int xGroups, int yGroups, int zGroups, int kernelIndex)
+    {
+        // The shader is not ready to be used.
+        if (!ShaderCompiler.Instance.GetShaderReady(this.m_shaderName)) return;
+
+        Rid globalShaderId = ShaderCompiler.Instance.GetComputeKernelCompilation(this.m_shaderName, 0);
+
+        // Recreate kernel pipelines if shader was recompiled
+        if (this.m_shader != globalShaderId)
+        {
+            this.m_shader = globalShaderId;
+            this.m_uniformSetGpuId = this.m_rd.UniformSetCreate(this.m_uniformSetCache, globalShaderId, 0);
+            this.m_kernels.Clear();
+
+            foreach (Rid kernel in ShaderCompiler.Instance.GetComputeKernelCompilations(this.m_shaderName))
+            {
+                this.m_kernels.Add(this.m_rd.ComputePipelineCreate(kernel));
+            }
+        }
+
+        // Reallocate GPU memory if uniforms need updating
+        if (this.m_refreshUniforms)
+        {
+            if (this.m_uniformSetGpuId.IsValid) this.m_rd.FreeRid(this.m_uniformSetGpuId);
+            this.m_uniformSetGpuId = this.m_rd.UniformSetCreate(this.m_uniformSetCache, globalShaderId, 0);
+            this.m_refreshUniforms = false;
+        }
+
+        long compute_list = this.m_rd.ComputeListBegin();
+        this.m_rd.ComputeListBindComputePipeline(compute_list, this.m_kernels[kernelIndex]);
+        this.m_rd.ComputeListBindUniformSet(compute_list, this.m_uniformSetGpuId, 0);
+        this.m_rd.ComputeListSetPushConstant(compute_list, this.m_pushConstant, (uint)this.m_pushConstant.Length);
+        this.m_rd.ComputeListDispatch(compute_list, (uint)xGroups, (uint)yGroups, (uint)zGroups);
+        this.m_rd.ComputeListEnd();
+    }
+
+    /// <summary>
+    /// Frees the shader resources.
+    /// </summary>
+    public void Free()
+    {
+        foreach (Rid kernel in this.m_kernels)
+        {
+            if (kernel.IsValid) this.m_rd.FreeRid(kernel);
+        }
+
+        foreach (Rid binding in this.m_uniformBufferIdCache.Values)
+        {
+            if (binding.IsValid) this.m_rd.FreeRid(binding);
+        }
+
+        if (this.m_uniformSetGpuId.IsValid) this.m_rd.FreeRid(this.m_uniformSetGpuId);
+    }
+
+    /// <summary>
+    /// Caches the provided uniform resource. If this uniform is new or updates an existing uniform,
+    /// the shader will recompute all requires sets on the next run.
+    /// </summary>
+    /// <param name="newUniform">The new uniform resource</param>
+    private void CacheUniform(RDUniform newUniform)
+    {
+        int uniformIndex = newUniform.Binding;
+
+        // Check to see if this uniform is new or replacing an old uniform
+        if (uniformIndex >= this.m_uniformSetCache.Count)
+        {
+            this.m_refreshUniforms = true;
+            this.m_uniformSetCache.Resize(uniformIndex + 1);
+        }
+
+        // If uniform has had its info changed then set flag to refresh gpu side uniform data
+        if (this.m_uniformSetCache[uniformIndex] != null)
+        {
+            Array<Rid> oldUniformIds = this.m_uniformSetCache[uniformIndex].GetIds();
+            Array<Rid> newUniformIds = newUniform.GetIds();
+
+            if (oldUniformIds.Count != newUniformIds.Count)
+            {
+                this.m_refreshUniforms = true;
+            }
+            else
+            {
+                for (int i = 0; i < oldUniformIds.Count; i++)
+                {
+                    if (oldUniformIds[i].Id != newUniformIds[i].Id)
+                    {
+                        this.m_refreshUniforms = true;
+                        break;
+                    }
+                }
+            }
+        }
+
+        this.m_uniformSetCache[uniformIndex] = newUniform;
+    }
+
+}

--- a/ShaderCompiler.cs
+++ b/ShaderCompiler.cs
@@ -1,0 +1,314 @@
+using Godot;
+using Godot.Collections;
+using System.Text.RegularExpressions;
+
+[Tool]
+public partial class ShaderCompiler : Node
+{
+    public static ShaderCompiler Instance { get; private set; }
+
+    private readonly RenderingDevice m_rd;
+    private readonly Array<string> m_computeShaderFilePaths = [];
+    private readonly System.Collections.Generic.Dictionary<string, string> m_shaderCodeCache = [];
+    private readonly System.Collections.Generic.Dictionary<string, Array<Rid>> m_computeShaderKernelCompilations = [];
+    private readonly System.Collections.Generic.Dictionary<string, bool> m_shaderReady = [];
+
+    /// <summary>
+    /// Creates a shader compilation class for processing acompute shader files.
+    /// </summary>
+    public ShaderCompiler() : base()
+    {
+        Instance = this;
+        this.m_rd = RenderingServer.GetRenderingDevice();
+        this.FindFiles("res://");
+        foreach (string filePath in this.m_computeShaderFilePaths) this.CompileComputeShader(filePath);
+    }
+
+    public override void _Process(double delta)
+    {
+        // Compare current shader code with cached shader code and recompile if changed
+        foreach (string filePath in this.m_computeShaderFilePaths)
+        {
+            // Check if we need to update the cache
+            if (this.m_shaderCodeCache[filePath] == LoadFromFile(filePath)) continue;
+
+            string shaderName = GetShaderName(filePath);
+
+            if (this.m_computeShaderKernelCompilations.TryGetValue(shaderName, out Array<Rid> kernelValues))
+            {
+                // Free existing kernels
+                foreach (Rid kernel in kernelValues)
+                {
+                    if (!kernel.IsValid) continue;
+                    this.m_rd.FreeRid(kernel);
+                }
+
+                this.m_shaderReady[shaderName] = false;
+                this.m_computeShaderKernelCompilations[shaderName].Clear();
+            }
+
+            // Compute the shader again
+            this.CompileComputeShader(filePath);
+        }
+    }
+
+    public override void _Notification(int what)
+    {
+        if (what != NotificationPredelete && what != NotificationWMCloseRequest) return;
+
+        foreach (string computeShader in this.m_computeShaderKernelCompilations.Keys)
+        {
+            foreach (Rid kernel in this.m_computeShaderKernelCompilations[computeShader])
+            {
+                if (!kernel.IsValid) continue;
+                this.m_rd.FreeRid(kernel);
+            }
+        }
+
+    }
+
+    /// <summary>
+    /// Returns the requested compute shader kernel or an empty <c>Rid</c>.
+    /// </summary>
+    /// <param name="shaderName"></param>
+    /// <param name="kernelIndex"></param>
+    /// <returns></returns>
+    public Rid GetComputeKernelCompilation(string shaderName, int kernelIndex)
+    {
+        // Check we have the requested kernel
+        if (!this.m_computeShaderKernelCompilations.TryGetValue(shaderName, out Array<Rid> kernels) || kernelIndex >= kernels.Count)
+        {
+            return new Rid();
+        }
+
+        return kernels[kernelIndex];
+    }
+
+    /// <summary>
+    /// Returns a list of kernels or <c>null</c> if the shader does not exist.
+    /// </summary>
+    /// <param name="shaderName"></param>
+    /// <returns></returns>
+    public Array<Rid> GetComputeKernelCompilations(string shaderName)
+    {
+        if (!this.m_computeShaderKernelCompilations.TryGetValue(shaderName, out Array<Rid> kernels))
+        {
+            return null;
+        }
+
+        return kernels;
+    }
+
+    /// <summary>
+    /// Returns <c>true</c> when the shader has been compiled successfully.
+    /// </summary>
+    /// <param name="shaderName"></param>
+    /// <returns></returns>
+    public bool GetShaderReady(string shaderName)
+    {
+        if (!this.m_shaderReady.TryGetValue(shaderName, out bool state))
+        {
+            return false;
+        }
+
+        return state;
+    }
+
+    /// <summary>
+    /// Performs the shader compilation for the request acompute file.
+    /// </summary>
+    /// <param name="computeShaderFilePath"></param>
+    private void CompileComputeShader(string computeShaderFilePath)
+    {
+        string computeShaderName = GetShaderName(computeShaderFilePath);
+        this.m_shaderReady[computeShaderName] = false;
+        GD.Print(string.Format("Compiling Compute Shader: {0}", computeShaderName));
+
+        using FileAccess file = FileAccess.Open(computeShaderFilePath, FileAccess.ModeFlags.Read);
+
+        if (file == null)
+        {
+            GD.PrintErr(string.Format("Unable to find shader file, {0}", computeShaderFilePath));
+            return;
+        }
+
+        string rawShaderCodeString = file.GetAsText();
+
+        // Store the code cache
+        this.m_shaderCodeCache[computeShaderFilePath] = rawShaderCodeString;
+
+        Array<string> kernelNames = [];
+        Array<string> rawShaderCode = [.. rawShaderCodeString.Split("\n")];
+
+        // Strip out kernel names
+        while (file.GetPosition() < file.GetLength())
+        {
+            string line = file.GetLine();
+
+            // Kernels must always come at the top of the file
+            if (!line.StartsWith("#kernel ")) break;
+
+            string kernelName = line.Split("#kernel")[1].StripEdges();
+            kernelNames.Add(kernelName);
+            rawShaderCode.RemoveAt(0);
+        }
+
+        // If no kernels defined at top of file, fail to compile
+        if (kernelNames.Count == 0)
+        {
+            GD.PushError(string.Format("Failed to compile: {0}", computeShaderFilePath));
+            GD.PushError("Reason: No kernels found");
+            return;
+        }
+
+        // If no code after kernel definitions or if nothing in file at all, fail to compile
+        if (file.GetPosition() >= file.GetLength())
+        {
+            GD.PushError(string.Format("Failed to compile: {0}", computeShaderFilePath));
+            GD.PushError("Reason: No shader code found");
+            return;
+        }
+
+        // Verify kernels exist
+        rawShaderCodeString = string.Join('\n', rawShaderCode);
+        foreach (string kernelName in kernelNames)
+        {
+            if (!MatchKernelName(rawShaderCodeString, kernelName))
+            {
+                GD.PushError(string.Format("Failed to compile: {0}", computeShaderFilePath));
+                GD.PushError(string.Format("Reason: {0} kernel not found!", kernelName));
+                return;
+            }
+        }
+
+        System.Collections.Generic.Dictionary<string, Array<string>> kernelToThreadGroupCount = [];
+
+        // Find kernels and extract thread groups
+        for (int i = 0; i < rawShaderCode.Count; i++)
+        {
+            string line = rawShaderCode[i];
+
+            foreach (string kernelName in kernelNames)
+            {
+                if (!line.Contains(kernelName) || !line.Contains("void")) continue;
+
+                // Find thread group count by searching previous line of code from kernel function
+                string newLine = rawShaderCode[i - 1].StripEdges();
+
+                if (!newLine.Contains("numthreads"))
+                {
+                    GD.PushError(string.Format("Failed to compile: {0}", computeShaderFilePath));
+                    GD.PushError("Reason: kernel thread group count not found");
+                    return;
+                }
+
+                string[] threadGroups = newLine.Split('(')[^1].Split(')')[0].Split(',');
+                if (threadGroups.Length != 3)
+                {
+                    GD.PushError(string.Format("Failed to compile: {0}", computeShaderFilePath));
+                    GD.PushError("Reason: kernel thread group syntax error");
+                    return;
+                }
+
+                kernelToThreadGroupCount[kernelName] = [];
+                for (int j = 0; j < threadGroups.Length; j++) kernelToThreadGroupCount[kernelName].Add(threadGroups[j].StripEdges());
+                rawShaderCode[i - 1] = "";
+            }
+        }
+
+        // Compile kernels
+        this.m_computeShaderKernelCompilations[computeShaderName] = [];
+
+        foreach (string kernelName in kernelNames)
+        {
+            // Clone the array
+            Array<string> shaderCode = [.. rawShaderCode];
+
+            // Insert GLSL thread group layout for the kernel
+            Array<string> threadGroup = kernelToThreadGroupCount[kernelName];
+            shaderCode.Insert(0, string.Format("layout(local_size_x = {0}, local_size_y = {1}, local_size_z = {2}) in;", threadGroup[0], threadGroup[1], threadGroup[2]));
+            shaderCode.Insert(0, "#version 450"); // Insert GLSL version at top of file
+
+            // Replace kernel name with main
+            string shaderCodeString = string.Join("\n", shaderCode).Replace(kernelName, "main");
+
+            // Compile shader
+            RDShaderSource shaderSource = new()
+            {
+                Language = RenderingDevice.ShaderLanguage.Glsl,
+                SourceCompute = shaderCodeString
+            };
+
+            RDShaderSpirV shaderSpirV = this.m_rd.ShaderCompileSpirVFromSource(shaderSource);
+
+            if (!string.IsNullOrEmpty(shaderSpirV.CompileErrorCompute))
+            {
+                GD.PushError(shaderSpirV.CompileErrorCompute);
+                GD.PushError(string.Format("In: {0}", shaderCodeString));
+                return;
+            }
+
+            GD.Print(string.Format("- Compiling Kernel: {0}", kernelName));
+            Rid shaderCompilation = this.m_rd.ShaderCreateFromSpirV(shaderSpirV);
+
+            if (!shaderCompilation.IsValid)
+            {
+                return;
+            }
+
+            this.m_computeShaderKernelCompilations[computeShaderName].Add(shaderCompilation);
+        }
+
+        this.m_shaderReady[computeShaderName] = true;
+    }
+
+    /// <summary>
+    /// Search the given directory and sub directories for files with the acompute file extension.
+    /// </summary>
+    /// <param name="directoryName"></param>
+    private void FindFiles(string directoryName)
+    {
+        using DirAccess directory = DirAccess.Open(directoryName);
+        if (directory == null) return;
+
+        directory.ListDirBegin();
+        string fileName = directory.GetNext();
+
+        while (!string.IsNullOrEmpty(fileName))
+        {
+
+            // Recursively search sub directories
+            if (directory.CurrentIsDir())
+            {
+                this.FindFiles(directoryName + '/' + fileName);
+            }
+            else if (fileName.GetExtension() == "acompute")
+            {
+                this.m_computeShaderFilePaths.Add(directoryName + '/' + fileName);
+            }
+
+            fileName = directory.GetNext();
+        }
+
+        directory.ListDirEnd();
+    }
+
+    private static bool MatchKernelName(string input, string kernelName)
+    {
+        string pattern = $@"\bvoid\s+{kernelName}\s*\(";
+        return Regex.IsMatch(input, pattern);
+    }
+
+    private static string GetShaderName(string filePath)
+    {
+        return filePath.GetFile().Split(".")[0];
+    }
+
+    private static string LoadFromFile(string filePath)
+    {
+        using var file = FileAccess.Open(filePath, FileAccess.ModeFlags.Read);
+        if (file == null) return "";
+        string content = file.GetAsText();
+        return content;
+    }
+}


### PR DESCRIPTION
I was in the process of creating a compute shader wrapper for Godot when I came across your implementation.

I've created a C# version which I believe might be able to help a few others. I've kept the logic as similar as I can to the Godot script implementation to hopefully help make any translations easier. I have also extended the shader wrapper to allow it to work with normal .glsl compute shaders.